### PR TITLE
unity-setup@v1.0.11

### DIFF
--- a/dist/install-unityhub-macos.sh
+++ b/dist/install-unityhub-macos.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+sudo sh -c 'dbus-uuidgen >/etc/machine-id && mkdir -p /var/lib/dbus/ && ln -sf /etc/machine-id /var/lib/dbus/machine-id'
 echo "::group::Installing Unity Hub..."
 baseUrl="https://public-cdn.cloud.unity3d.com/hub/prod"
 url="$baseUrl/UnityHubSetup.dmg"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "unity-setup",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "unity-setup",
-      "version": "1.0.10",
+      "version": "1.0.11",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-setup",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "A GitHub action for setting up the Unity Game Engine for CI/CD workflows.",
   "author": "Buildalon",
   "license": "MIT",

--- a/src/install-unityhub-macos.sh
+++ b/src/install-unityhub-macos.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+sudo sh -c 'dbus-uuidgen >/etc/machine-id && mkdir -p /var/lib/dbus/ && ln -sf /etc/machine-id /var/lib/dbus/machine-id'
 echo "::group::Installing Unity Hub..."
 baseUrl="https://public-cdn.cloud.unity3d.com/hub/prod"
 url="$baseUrl/UnityHubSetup.dmg"


### PR DESCRIPTION
- randomize macOS machine name to reduce license activation errors

## Copilot Summary:
This pull request includes a version bump and a fix for Unity Hub installation on macOS.

Version bump:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `1.0.10` to `1.0.11`.

Installation fix:

* [`src/install-unityhub-macos.sh`](diffhunk://#diff-ed332307f78fce3e0d67e286024f03cb6c335897044075289f1ee597a29f0eeeR3): Added a command to generate a machine ID and create necessary directories and links to ensure Unity Hub installs correctly on macOS.